### PR TITLE
Bugfix body response

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -83,7 +83,11 @@
                             "properties":{
                                 "body": {
                                     "description": "Contains the body of the response from the end-point.",
-                                    "type": "object"
+                                    "type": [
+                                        "object",
+                                        "string",
+                                        "array"
+                                    ]
                                 },
                                 "headers": {
                                     "description": "Contains the headers of the response from the end-point.",


### PR DESCRIPTION
Was originally set to only be an Object but it should allow for an array, object and a string now matches that of the `request.body`.
